### PR TITLE
fix: ignore renovate

### DIFF
--- a/config/admin/integrations/github-webhook.js
+++ b/config/admin/integrations/github-webhook.js
@@ -30,6 +30,9 @@ const githubEvents = {
   issues(request) {
     const user = request.content.sender;
 
+    // Ignore Renovate
+    if (user.login === 'renovate[bot]') return;
+
     if (request.content.action == "opened" || request.content.action == "reopened" || request.content.action == "edited") {
         var body = request.content.action + " by: " + user.login;
     } else if (request.content.action == "labeled") {
@@ -71,6 +74,9 @@ const githubEvents = {
   issue_comment(request) {
     const user = request.content.comment.user;
 
+    // ignore renovate
+    if (user.login === 'renovate[bot]') return;
+
     if (request.content.action == "edited") {
         var action = "Edited comment ";
     } else {
@@ -93,6 +99,8 @@ const githubEvents = {
  /* COMMENT ON COMMIT */
 commit_comment(request) {
     const user = request.content.comment.user;
+
+    if (user.login === 'renovate[bot]') return;
 
     if (request.content.action == "edited") {
         var action = "Edited comment ";
@@ -128,6 +136,8 @@ commit_comment(request) {
     }
     const user = request.content.sender;
 
+    if (user.login === 'renovate[bot]') return;
+
     var text = '**Pushed to ' + "["+request.content.repository.full_name+"]("+request.content.repository.url+"):"
                 + request.content.ref.split('/').pop() + "**\n\n";
 
@@ -158,6 +168,8 @@ commit_comment(request) {
   /* NEW PULL REQUEST */
   pull_request(request) {
     const user = request.content.sender;
+
+    if (user.login === 'renovate[bot]') return;
 
    if (request.content.action == "opened" || request.content.action == "reopened" || request.content.action == "edited") {
         var body = request.content.action + ' by: ' + user.login;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Early return if the action is triggered by Renovate. Should help
keep the channels a bit cleaner. Tested locally via manual `POST` requests.

Requested by @ojeytonwilliams 