### PR TITLE
Removed trailing double quotes from pt-BR greeting

### DIFF
--- a/config/admin/layout/content--home-body.html
+++ b/config/admin/layout/content--home-body.html
@@ -514,7 +514,7 @@
       Olá! Que bom ver você aqui no chat oficial da comunidade do freeCodeCamp!
       Visite o nosso canal,
       <a href="/channel/brazilian-portuguese">#brazilian-portuguese</a>, e nos
-      conte um pouco sobre você."
+      conte um pouco sobre você.
     </h4>
 
     <h4 style="direction:rtl;">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Just doing away with an annoying extra trailing quote.